### PR TITLE
Fixed reference to missing attribute pkgs.perl.version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@ pkgs.stdenv.mkDerivation {
   ];
 
   installPhase = ''
-    PERL_LIB=$out/lib/perl5/site_perl/${pkgs.perl.version}
+    PERL_LIB=$out/lib/perl5/site_perl/${pkgs.perl}
     mkdir -p $PERL_LIB
     cp -v -r $src/lib/* $PERL_LIB
 


### PR DESCRIPTION
It does not seem to exist.
Simply removing `.version` works like charm.

Details:
```
$ cd /<path-to-repo>/psc-package2nix/
$ nix-env -if .
replacing old 'psc-package2nix'
installing 'psc-package2nix'
error: attribute 'version' missing, at /<path-to-repo>/psc-package2nix/default.nix:13:41
(use '--show-trace' to show detailed location information)
```